### PR TITLE
fix: map vis toggle button not clickable in firefox

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -208,7 +208,12 @@ const GlobalStyle = createGlobalStyle`
     text-decoration: none;
     &:hover { background-color: #3baacc; color: white; }
   }
-  .btn-map { background-color: #fff; float: left; margin: 0 2rem 1rem 0; }
+  .btn-map { 
+    background-color: #fff; 
+    float: left; 
+    margin: 0 2rem 1rem 0; 
+    z-index: 1; 
+  }
   footer a { color: #fcfcf4; text-decoration: none; }
   .footer-logo {
     background-color: #354156;


### PR DESCRIPTION
Small fix for the toggle button for map-vis that I just noticed that isn't clickable in firefox

Bug:
![deepin-screen-recorder_Navigator_20210720153524](https://user-images.githubusercontent.com/59235022/126379016-bebcf7d1-344c-4ccb-9da5-9dd11fdcb46a.gif)
